### PR TITLE
Fix location of normalize.css in stylus template

### DIFF
--- a/app/templates/src/index.styl
+++ b/app/templates/src/index.styl
@@ -1,5 +1,5 @@
 // Normalize Styles
-@import '../../node_modules/normalize.css/normalize.css';
+@import '../node_modules/normalize.css/normalize.css';
 
 // Box sizing partial styles
 // Apply a natural box layout model to all elements


### PR DESCRIPTION
I'm pretty a newbie when it comes to front-end, but I think I found a 3-chars bug in a `styl` file...
